### PR TITLE
Timestamp commits using Gitstamp

### DIFF
--- a/.github/workflows/gitstamp.yaml
+++ b/.github/workflows/gitstamp.yaml
@@ -1,0 +1,16 @@
+# See: https://github.com/weavery/gitstamp-action
+---
+name: Gitstamp
+on: [push]
+jobs:
+  gitstamp:
+    runs-on: ubuntu-latest
+    name: Timestamp commit with Gitstamp
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Submit Gitstamp transaction
+        uses: weavery/gitstamp-action@v1
+        with:
+          wallet-key: ${{ secrets.GITSTAMP_KEYFILE }}
+          commit-link: true


### PR DESCRIPTION
As per https://github.com/ArweaveTeam/arweave-js/pull/54. Sam says we want [Gitstamp](https://gitstamp.dev) for all repositories, so here goes 😃 